### PR TITLE
Add support for mapping SQL constraints (UNIQUE, VARCHAR length, NOT …

### DIFF
--- a/src/main/java/cl/playground/core/engine/PostgresEngine.java
+++ b/src/main/java/cl/playground/core/engine/PostgresEngine.java
@@ -13,7 +13,7 @@ public class PostgresEngine implements DatabaseEngine {
             Pattern.CASE_INSENSITIVE
     );
     private static final Pattern COLUMN_PATTERN = Pattern.compile(
-            "(\\w+)\\s+(\\w+)(?:\\([^)]+\\))?(\\s+[^,]+)?",
+            "(\\w+)\\s+(\\w+)(?:\\(([^)]+)\\))?(\\s+[^,]+)?",
             Pattern.CASE_INSENSITIVE
     );
     private static final Pattern FOREIGN_KEY_PATTERN = Pattern.compile(
@@ -73,10 +73,13 @@ public class PostgresEngine implements DatabaseEngine {
         while (columnMatcher.find()) {
             String columnName = columnMatcher.group(1);
             String columnType = columnMatcher.group(2);
-            String constraints = columnMatcher.group(3);
+            String size = columnMatcher.group(3);
+            String constraints = columnMatcher.group(4);
 
             boolean isNullable = constraints == null || !constraints.toLowerCase().contains("not null");
+            boolean isUnique = constraints != null && constraints.toLowerCase().contains("unique");
             String defaultValue = extractDefaultValue(constraints);
+            String length = columnType.toLowerCase().contains("varchar") ? size : null;
 
             // Verificar si es foreign key primero
             if (constraints != null) {
@@ -87,9 +90,11 @@ public class PostgresEngine implements DatabaseEngine {
                     // Para foreign keys, usamos el tipo de la entidad referenciada
                     ColumnDefinition column = new ColumnDefinition(
                             columnName,
-                            referencedTableName, // Usamos el nombre de la tabla como tipo
+                            referencedTableName,
                             isNullable,
-                            defaultValue
+                            defaultValue,
+                            isUnique,
+                            length
                     );
                     tableDefinition.addColumn(column);
 
@@ -108,7 +113,9 @@ public class PostgresEngine implements DatabaseEngine {
                     columnName,
                     columnType,
                     isNullable,
-                    defaultValue
+                    defaultValue,
+                    isUnique,
+                    length
             );
 
             if (isPrimaryKey(constraints)) {
@@ -130,10 +137,12 @@ public class PostgresEngine implements DatabaseEngine {
                 if (referencedClass != null) {
                     String fieldName = fk.getColumnName().replace("_id", "");
                     ColumnDefinition relationColumn = new ColumnDefinition(
-                            fieldName,
-                            referencedClass.getClassName(),
-                            true,
-                            null
+                            fieldName,                    // columnName
+                            referencedClass.getClassName(), // columnType
+                            true,                         // isNullable
+                            null,                         // defaultValue
+                            false,                        // isUnique
+                            null                          // length
                     );
                     classDefinition.addAttribute(relationColumn);
 

--- a/src/main/java/cl/playground/core/model/ColumnDefinition.java
+++ b/src/main/java/cl/playground/core/model/ColumnDefinition.java
@@ -6,12 +6,24 @@ public class ColumnDefinition {
     private final String columnType;
     private final boolean isNullable;
     private final String defaultValue;
+    private final boolean isUnique;
+    private final String length;
 
-    public ColumnDefinition(String columnName, String columnType, boolean isNullable, String defaultValue) {
+    public ColumnDefinition(String columnName, String columnType, boolean isNullable, String defaultValue, boolean isUnique, String length) {
         this.columnName = columnName;
         this.columnType = columnType;
         this.isNullable = isNullable;
         this.defaultValue = defaultValue;
+        this.isUnique = isUnique;
+        this.length = length;
+    }
+
+    public boolean isUnique() {
+        return isUnique;
+    }
+
+    public String getLength() {
+        return length;
     }
 
     public String getColumnName() {

--- a/src/main/java/cl/playground/core/strategy/JpaStrategy.java
+++ b/src/main/java/cl/playground/core/strategy/JpaStrategy.java
@@ -25,13 +25,28 @@ public class JpaStrategy implements EntityStrategy {
                     .append("    @GeneratedValue(strategy = GenerationType.IDENTITY)\n")
                     .append("    @Column(name = \"").append(column.getColumnName()).append("\")\n");
         } else if (isForeignKey) {
-            annotations.append("\", nullable = ").append(column.isNullable() ? "true" : "false")
+            annotations.append("    @ManyToOne\n")
+                    .append("    @JoinColumn(name = \"").append(column.getColumnName())
+                    .append("\", nullable = ").append(column.isNullable() ? "true" : "false")
                     .append(")\n");
         } else {
             annotations.append("    @Column(name = \"").append(column.getColumnName()).append("\"");
+
+            // Agregar longitud si existe
+            if (column.getLength() != null) {
+                annotations.append(", length = ").append(column.getLength());
+            }
+
+            // Agregar nullable si es false
             if (!column.isNullable()) {
                 annotations.append(", nullable = false");
             }
+
+            // Agregar unique si es true
+            if (column.isUnique()) {
+                annotations.append(", unique = true");
+            }
+
             annotations.append(")\n");
         }
 


### PR DESCRIPTION
…NULL) to JPA entities

Implemented functionality to map SQL constraints to JPA-compatible entity classes.

- Added  class to capture key SQL column attributes such as , , , and .
- Updated  to parse SQL constraints like , , and column lengths () using enhanced regex patterns.
- Modified  to process column constraints and populate  objects accordingly.
- Ensured attributes like  and  are accurately represented when generating class definitions.
- Skipped  constraint handling for now, as it would require additional logic or an , which is not prioritized at this moment.

These changes ensure that SQL table definitions are more accurately reflected in the generated JPA entities while maintaining flexibility for future enhancements.

fix Issue #4 
close Issue #4 